### PR TITLE
use location.hostname instead of hardcoded "localhost"

### DIFF
--- a/resources/html/geister_viewer.js
+++ b/resources/html/geister_viewer.js
@@ -83,7 +83,7 @@
     GameOfGeister.prototype.state = '';
 
     function GameOfGeister() {
-      this.ws = new WebSocket('ws://localhost:8080/ws/geister');
+      this.ws = new WebSocket('ws://' + window.location.hostname + ':8080/ws/geister');
       this.createCanvas();
       this.resizeCanvas();
       this.createDrawingContext();


### PR DESCRIPTION
リモートのUbuntuで動いているWebSocketサーバに対して手元のWindowsのブラウザで接続したいが、ブラウザから見てWebSocketサーバの位置がlocalhostではないので可能ならこう変えたい。